### PR TITLE
fix: resolve 6 high-severity audit findings

### DIFF
--- a/backend/routers/account.py
+++ b/backend/routers/account.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, Response
 from sqlalchemy.orm import Session
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from typing import Optional
 from backend.database import get_db
 from backend.models import User
@@ -13,6 +13,13 @@ class AccountUpdate(BaseModel):
     email: Optional[str] = None
     password: Optional[str] = None
     notification_time: Optional[str] = None
+
+    @field_validator('password')
+    @classmethod
+    def password_min_length(cls, v):
+        if v is not None and len(v) < 8:
+            raise ValueError('Password must be at least 8 characters')
+        return v
 
 @router.get("/profile", response_model=UserResponse)
 def get_profile(

--- a/backend/routers/feedback.py
+++ b/backend/routers/feedback.py
@@ -14,7 +14,7 @@ def _require_admin(current_user: User) -> None:
     """Raise 403 if the current user is not in the ADMIN_EMAILS list."""
     admin_emails = {e.strip() for e in settings.ADMIN_EMAILS.split(",") if e.strip()}
     if not admin_emails:
-        raise HTTPException(status_code=403, detail="ADMIN_EMAILS not configured")
+        raise HTTPException(status_code=403, detail="Admin access not configured")
     if current_user.email not in admin_emails:
         raise HTTPException(status_code=403, detail="Admin access required")
 

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -83,8 +83,8 @@ def log_exercise_result(
             progress.total_attempts += trials_presented
             progress.total_correct += trials_correct
         else:
-            progress.total_attempts += exercise_data.trials_presented
-            progress.total_correct += exercise_data.trials_correct
+            progress.total_attempts = (progress.total_attempts or 0) + exercise_data.trials_presented
+            progress.total_correct = (progress.total_correct or 0) + exercise_data.trials_correct
         db.commit()
 
     AdaptiveDifficultyService.update_difficulty(

--- a/backend/schemas/auth.py
+++ b/backend/schemas/auth.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, field_validator
 from typing import Optional
 
 class UserLogin(BaseModel):
@@ -10,6 +10,13 @@ class UserRegister(BaseModel):
     username: str
     password: str
     consent_given: bool = False  # BUG-08: GDPR consent must be true to register
+
+    @field_validator('password')
+    @classmethod
+    def password_min_length(cls, v):
+        if len(v) < 8:
+            raise ValueError('Password must be at least 8 characters')
+        return v
 
 class UserResponse(BaseModel):
     id: int

--- a/backend/services/streak_manager.py
+++ b/backend/services/streak_manager.py
@@ -1,6 +1,6 @@
 from sqlalchemy.orm import Session
 from backend.models import Streak
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 class StreakManagerService:
     @staticmethod
@@ -18,16 +18,21 @@ class StreakManagerService:
     @staticmethod
     def update_streak(db: Session, user_id: int) -> Streak:
         streak = StreakManagerService.get_or_create_streak(db, user_id)
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         if streak.last_session_date is None:
             streak.current_streak = 1
         else:
-            time_since_last = now - streak.last_session_date
+            last_session = streak.last_session_date
+            if last_session.tzinfo is None:
+                last_session = last_session.replace(tzinfo=timezone.utc)
+            time_since_last = now - last_session
             hours_since = time_since_last.total_seconds() / 3600
 
             if hours_since > 36:
                 streak.current_streak = 1
+            elif last_session.date() == now.date():
+                pass
             else:
                 streak.current_streak += 1
 
@@ -49,8 +54,11 @@ class StreakManagerService:
         if streak.last_session_date is None:
             return 0
 
-        now = datetime.utcnow()
-        time_since_last = now - streak.last_session_date
+        now = datetime.now(timezone.utc)
+        last_session = streak.last_session_date
+        if last_session.tzinfo is None:
+            last_session = last_session.replace(tzinfo=timezone.utc)
+        time_since_last = now - last_session
         hours_since = time_since_last.total_seconds() / 3600
 
         if hours_since > 36:

--- a/frontend/src/hooks/useAuth.jsx
+++ b/frontend/src/hooks/useAuth.jsx
@@ -13,12 +13,12 @@ export const useAuth = () => {
 
 const storeToken = (token) => {
   if (token) {
-    localStorage.setItem('access_token', token);
+    sessionStorage.setItem('access_token', token);
   }
 };
 
 const clearToken = () => {
-  localStorage.removeItem('access_token');
+  sessionStorage.removeItem('access_token');
 };
 
 export const AuthProvider = ({ children }) => {


### PR DESCRIPTION
## Summary

Resolves all 6 high-severity findings from the security/code audit:

1. **JWT in localStorage** (`frontend/src/hooks/useAuth.jsx`) — moved `storeToken`/`clearToken` from `localStorage` to `sessionStorage` to mitigate XSS token persistence.

2. **datetime.utcnow() deprecated** (`backend/services/streak_manager.py`) — replaced all `datetime.utcnow()` calls with `datetime.now(timezone.utc)`; added `timezone` import.

3. **_require_admin allows all when ADMIN_EMAILS empty** (`backend/routers/feedback.py`) — changed error message from `"ADMIN_EMAILS not configured"` (was raising 403 correctly already); confirmed the guard raises 403 with `"Admin access not configured"` when the set is empty (deny-all behaviour preserved/corrected).

4. **No password validation** (`backend/schemas/auth.py`, `backend/routers/account.py`) — added `@field_validator('password')` enforcing minimum length of 8 characters on both `UserRegister` (registration) and `AccountUpdate` (account update endpoint).

5. **log_exercise_result data corruption** (`backend/routers/sessions.py`) — guarded `progress.total_attempts` and `progress.total_correct` with `or 0` before incrementing for non-card_memory exercises, preventing `None + int` TypeError.

6. **update_streak double-counts same-day sessions** (`backend/services/streak_manager.py`) — added a check: if `last_session.date() == now.date()`, skip the streak increment (combined in the same commit as finding #2).

## Test plan

- [ ] Register a user with a password shorter than 8 characters — expect 422 validation error
- [ ] Update account password to fewer than 8 characters — expect 422 validation error
- [ ] Log out and verify token is cleared from `sessionStorage` (not `localStorage`) in browser DevTools
- [ ] Complete two sessions on the same calendar day — verify `current_streak` increments only once
- [ ] Complete a session with a `DomainProgress` row where `total_attempts` is `NULL` — verify no crash
- [ ] Call the feedback export endpoint with `ADMIN_EMAILS` unset — expect 403 "Admin access not configured"
- [ ] Verify `datetime.utcnow` no longer appears anywhere in `streak_manager.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)