### PR TITLE
fix: align token storage to sessionStorage in axios interceptor

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -11,7 +11,7 @@ const client = axios.create({
 });
 
 client.interceptors.request.use((config) => {
-  const token = localStorage.getItem('access_token');
+  const token = sessionStorage.getItem('access_token');
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
   }
@@ -24,7 +24,7 @@ client.interceptors.response.use(
     const isAuthCheck = error.config?.url?.includes('/api/auth/me');
     const isPublicPage = ['/login', '/register', '/'].includes(window.location.pathname);
     if (error.response?.status === 401 && !isAuthCheck && !isPublicPage) {
-      localStorage.removeItem('access_token');
+      sessionStorage.removeItem('access_token');
       window.location.href = '/login';
     }
     return Promise.reject(error);


### PR DESCRIPTION
Commit 36a0920 moved token storage from localStorage to sessionStorage
in useAuth.jsx but left the axios request interceptor in client.js still
reading from localStorage. This caused every authenticated API call to
silently omit the Bearer token, resulting in immediate 401 errors and a
redirect to /login right after a successful login.

Both localStorage references in client.js updated to sessionStorage.

https://claude.ai/code/session_0136WHLBui8QkjTu4iXpTLsr