### PR TITLE
fix: add project_id to feedback_entries for cross-project isolation

### DIFF
--- a/backend/models/feedback_entry.py
+++ b/backend/models/feedback_entry.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, Boolean
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
 from sqlalchemy.orm import relationship
 from datetime import datetime, timezone
 from backend.database import Base
@@ -12,6 +12,7 @@ class FeedbackEntry(Base):
     page_context = Column(String, nullable=False)  # max 100 chars in practice
     session_id = Column(Integer, ForeignKey("sessions.id"), nullable=True)
     feedback_text = Column(String, nullable=False)  # max 1000 chars in practice
+    project_id = Column(String, nullable=False, default="brain-training")
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
     processed_at = Column(DateTime, nullable=True)
 

--- a/backend/routers/feedback.py
+++ b/backend/routers/feedback.py
@@ -9,6 +9,8 @@ from backend.security import get_current_user, get_current_user_optional
 
 router = APIRouter(prefix="/api/feedback", tags=["feedback"])
 
+PROJECT_ID = "brain-training"
+
 
 def _require_admin(current_user: User) -> None:
     """Raise 403 if the current user is not in the ADMIN_EMAILS list."""
@@ -42,6 +44,7 @@ def submit_feedback(
         page_context=feedback_data.page_context,
         session_id=feedback_data.session_id,
         feedback_text=feedback_data.feedback_text,
+        project_id=PROJECT_ID,
     )
     db.add(feedback)
     db.commit()


### PR DESCRIPTION
## Summary

Fixes cross-project feedback contamination where Brain Training user feedback was creating issues in the Family Chores repo.

**Root cause:** Both projects' review pipelines connected to the same database and queried \`feedback_entries\` without a project filter. Whichever pipeline ran first claimed all unprocessed feedback and created issues in its own repo.

**Changes:**
- \`backend/models/feedback_entry.py\` — adds \`project_id\` column (SQLAlchemy model)
- \`backend/routers/feedback.py\` — explicitly sets \`project_id = 'brain-training'\` on every new \`FeedbackEntry\`

## Database migration required

Before merging, run the following against the Brain Training PostgreSQL database. The \`DEFAULT 'brain-training'\` ensures all existing rows are backfilled automatically — no separate UPDATE needed:

\`\`\`sql
ALTER TABLE feedback_entries
  ADD COLUMN IF NOT EXISTS project_id TEXT NOT NULL DEFAULT 'brain-training';
\`\`\`

## Test plan

- [ ] Run SQL migration against the database
- [ ] Confirm existing rows all have \`project_id = 'brain-training'\`
- [ ] Submit a test feedback entry via the app and confirm \`project_id\` is set
- [ ] Trigger Brain Training nightly-review manually — confirm only Brain Training feedback is processed
- [ ] Trigger Family Chores nightly-review manually — confirm 0 feedback rows are fetched

🤖 Generated with [Claude Code](https://claude.com/claude-code)