### PR TITLE
fix: rename groups_dict → entries_by_context (#132) and TRIALS_PER_ROUND magic number (#133)

### DIFF
--- a/backend/routers/feedback.py
+++ b/backend/routers/feedback.py
@@ -90,16 +90,16 @@ def export_feedback(
     entries = query.order_by(FeedbackEntry.created_at.desc()).all()
 
     # Group by page_context
-    groups_dict = {}
+    entries_by_context = {}
     for entry in entries:
         context = entry.page_context
-        if context not in groups_dict:
-            groups_dict[context] = []
-        groups_dict[context].append(FeedbackResponse.model_validate(entry))
+        if context not in entries_by_context:
+            entries_by_context[context] = []
+        entries_by_context[context].append(FeedbackResponse.model_validate(entry))
 
     groups = [
         FeedbackEntryGroup(page_context=context, entries=feedback_list)
-        for context, feedback_list in sorted(groups_dict.items())
+        for context, feedback_list in sorted(entries_by_context.items())
     ]
 
     return FeedbackExportResponse(total=len(entries), groups=groups)

--- a/frontend/src/components/exercises/VisualCategorisation.jsx
+++ b/frontend/src/components/exercises/VisualCategorisation.jsx
@@ -12,7 +12,7 @@ const FILLS   = ['solid', 'outline'];
 const STUDY_PER_GROUP = 3;
 const TOTAL_TRIALS    = 12;
 const NUM_ROUNDS      = 3;
-const TRIALS_PER_ROUND = Math.round(TOTAL_TRIALS / 4);
+const TRIALS_PER_ROUND = Math.round(TOTAL_TRIALS / NUM_ROUNDS);
 
 // ─── Classification rules ────────────────────────────────────────────────────
 const RULES = {


### PR DESCRIPTION
## Summary

Two code fixes from the implementation pipeline failures on 2026-04-28.

**#132 — Rename `groups_dict` → `entries_by_context` in `export_feedback`**
Pure local-variable rename inside the `export_feedback` function. No API or schema changes. The previous pipeline run introduced a regression in this function causing 422 responses; this commit restores the correct implementation with the rename applied cleanly.

**#133 — Replace magic number `4` with `NUM_ROUNDS` in `TRIALS_PER_ROUND` calculation**
```js
// Before
const TRIALS_PER_ROUND = Math.round(TOTAL_TRIALS / 4);  // = 3 (inconsistent with TOTAL_TRIALS=12)
// After
const TRIALS_PER_ROUND = Math.round(TOTAL_TRIALS / NUM_ROUNDS);  // = 4 (12/3, consistent)
```
This also fixes the latent inconsistency where only 9 of 12 total trials were played (3 rounds × 3 trials). Now 3 × 4 = 12, matching `TOTAL_TRIALS`.

Closes #132
Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)